### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ MCP server for interacting with Prometheus metrics and data.
 
 This is a TypeScript-based MCP server that implements a Prometheus API interface. It provides a bridge between Claude and your Prometheus server through the Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/y7b3qba8jy"><img width="380" height="200" src="https://glama.ai/mcp/servers/y7b3qba8jy/badge" alt="mcp-server-prometheus MCP server" /></a>
+
 ## Demo
 
 ![demo](/demo.png)


### PR DESCRIPTION
This PR adds a badge for the mcp-server-prometheus server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/y7b3qba8jy"><img width="380" height="200" src="https://glama.ai/mcp/servers/y7b3qba8jy/badge" alt="mcp-server-prometheus MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.